### PR TITLE
MacVim + ZSH + RVM

### DIFF
--- a/content/integration/vim.haml
+++ b/content/integration/vim.haml
@@ -18,3 +18,29 @@
 %p
   Thanks to Michael Shapiro for providing this patch.
 
+%h3 MacVim, ZSH and rvm rubies.
+
+%p
+  If you are using ZSH you may find that MacVim is not loading your rvm configuration
+  correctly. This may be because you are sourcing the rvm scripts in your .zshrc
+  file.
+
+  MacVim does not source the .zshrc file, but will source the .zshenv file. To ensure
+  that MacVim correctly loads rvm for its shell, and running ruby commands, source
+  the rvm scripts from withing .zshenv.
+
+  Alternatively, you can add:
+
+%pre
+  %code
+    set shell=/bin/sh
+
+%p
+  to your .vimrc, and ensure vim always runs from a simple shell, and ensure you
+  source rvm from within your .profile file.
+
+%p
+  Thanks to
+  %a{:href => 'http://github.com/hpoydar'} Henry Poydar
+  for finding this
+  %a{:href=> 'http://gabebw.wordpress.com/2010/08/02/rails-vim-rvm-and-a-curious-infuriating-bug/'} blog post


### PR DESCRIPTION
Small doc to change to explain having macvim recognise rvm rubies when using ZSH.
