### PR TITLE
Workflow examples system gem install: minor bugfix

### DIFF
--- a/content/workflow/examples.haml
+++ b/content/workflow/examples.haml
@@ -165,5 +165,5 @@
   Install gems from system gem dir (osx: /Library/Ruby/Gems/1.8) using current ruby
 %pre.code
   :preserve
-    $  rvm system ; rvm gemset export system ; rvm 1.8.7 ; rvm gemset import system
+    $  rvm system ; rvm gemset export system.gems ; rvm 1.8.7 ; rvm gemset import system
 


### PR DESCRIPTION
Updated the instructions for migrating the standard Snow Leopard 1.8.7 gems into an rvm 1.8.7 gemset.

Thankyouthankyouthankyou for RVM!
- Bill
