### PR TITLE
Removed what I believe is a typo from the gemsets deleting page

### DIFF
--- a/content/gemsets/deleting.haml
+++ b/content/gemsets/deleting.haml
@@ -21,7 +21,7 @@
 %pre.code
   :preserve
     $ rvm gemset albinochipmunk
-    $ rvm --force gemset delete albinochipmunk"
+    $ rvm --force gemset delete albinochipmunk
 %p
   By default, rvm will try to delete gemsets from the currently selected Ruby interpreter. If you want to delete a gemset from a different interpreter, run the command this way:
 %pre.code


### PR DESCRIPTION
I think the extra double quote at the end of that line is a typo.
