### PR TITLE
Update packages page

### DIFF
--- a/content/packages.haml
+++ b/content/packages.haml
@@ -20,3 +20,16 @@
       %a{:href => "/packages/openssl/"} OpenSSL
     %li
       %a{:href => "/packages/autoconf/"} Autoconf
+%p
+  Also available using rvm:
+  %ul
+    %li curl
+    %li gettext
+    %li glib
+    %li libxml2
+    %li libxslt
+    %li libyaml
+    %li llvm
+    %li mono
+    %li ncurses
+    %li pkgconfig


### PR DESCRIPTION
At the moment, the packages page is potentially deceptive: it only mentions the five items with separate pages. This adds a bare listing of everything that `rvm` can install.
