### PR TITLE
Disable install doc

### DIFF
--- a/content/support/troubleshooting.haml
+++ b/content/support/troubleshooting.haml
@@ -184,6 +184,10 @@
 %p
   Occasionally a build will fail because the build process picks up an an
   existing rdoc in your path. If this happens, you can add a configuration
-  option that will prevent the documentation being built then:
+  option that will prevent the documentation being built during installation:
 %pre.code
   rvm install <ruby-version> --disable-install-doc
+%p
+  Alternatively, you can try installing a newer version of rdoc to the current
+  environment. That way, the newer rdoc should be able to handle documentation
+  from the more recent version of Ruby that you're installing.


### PR DESCRIPTION
A brief listing of two ways to fix rdoc parsing problems preventing new installs.
