### PR TITLE
rvm-site error in 'our scripting page' link

### DIFF
--- a/content/integration/capistrano.haml
+++ b/content/integration/capistrano.haml
@@ -32,7 +32,7 @@
   %strong will not
   be automatically loaded as a shell function but it will be available as a
   binary in PATH (for differences between the two versions, please see
-  %a{:href => "/integration/scripting/"} our scripting page
+  %a{:href => "/workflow/scripting/"} our scripting page
   for further clarification).
 
 %p


### PR DESCRIPTION
Wayne,
thanks for rvm !

In http://rvm.beginrescueend.com/integration/capistrano/ page,
the link named "our scripting page " should point to
  http://rvm.beginrescueend.com/workflow/scripting/ 
instead of
  http://rvm.beginrescueend.com/integration/scripting/

Regards,
David
