### PR TITLE
Updated system-wide install documentation

### DIFF
--- a/content/rvm/install.haml
+++ b/content/rvm/install.haml
@@ -11,10 +11,12 @@
   %li System Wide (Multiple Users, Installed via Root).
 
 %p
-  If you wish to install rvm system wide, please read our
-  %a{:href => "/deployment/system-wide/"} system-wide installation guide
-  which takes a slightly different approach to the method
-  highlighted below.
+  Installing rvm system wide is discouraged and we no longer provide support for this,
+  if you still want to do so you can follow the steps in
+	%a{:href => 'http://lee.jarvis.co/rvm-plays-nice-on-production/'} this article
+	or ping
+	%em injekt
+	in the rvm IRC channel.
 
 %p
   Don't forget to set your


### PR DESCRIPTION
Wayne,

I understand you've removed the system-wide installation docs and script, and I think this is the right choice. I'm more than willing to continue to maintain the [RVM plays nice on production](http://lee.jarvis.co/rvm-plays-nice-on-production/) article, as it's still something I follow myself for new system wide installations, and I'm also happy to provide support for this to people inside the rvm channel. 

This commit adds an external link to the article providing this support, and removes the internal link to the old system-wide installation doc page.

If you'd rather not do so, you'll still need to ensure the internal link is removed :)
