### PR TITLE
Minor filename fix in installation instructions

### DIFF
--- a/content/rvm/install.haml
+++ b/content/rvm/install.haml
@@ -83,11 +83,11 @@
 
 %h3 Installing / updating the latest rvm from the latest released source tarball
 
-= sh_cmd "curl -L http://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-install latest"
+= sh_cmd "curl -L http://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-installer latest"
 
 %h3 Installing a specific version
 
-= sh_cmd "curl -L http://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-install 1.5.3"
+= sh_cmd "curl -L http://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-installer 1.5.3"
 
 %h2 Post Install
 


### PR DESCRIPTION
I noticed that the example commands for "Installing / updating the latest rvm from the latest released source tarball" and "Installing a specific version" download into "rvm-installer", but execute "rvm-install" ... This patch fixes those two spots. (Note: sinfully, I didn't do anything but edit the source files, sorry. Will be more diligent next time, but am under the gun on a work project). Thanks as always for the fine continuing RVM work!

Best,
...Bryan Stearns
