### PR TITLE
Minor filename fix in installation instructions UPDATED

### DIFF
--- a/content/rvm/install.haml
+++ b/content/rvm/install.haml
@@ -83,11 +83,11 @@
 
 %h3 Installing / updating the latest rvm from the latest released source tarball
 
-= sh_cmd "curl -s https://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-install latest"
+= sh_cmd "curl -s https://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-installer --version lastest"
 
 %h3 Installing a specific version
 
-= sh_cmd "curl -s https://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-install 1.5.3"
+= sh_cmd "curl -s https://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-installer 1.5.3"
 
 %h2 Post Install
 


### PR DESCRIPTION
[Bryan has already reported it](https://github.com/wayneeseguin/rvm-site/pull/33), but I found yet another error. Currently for the latest version we need to exactly write `--version lastest`.
