### PR TITLE
rbx interpreter documentation update

### DIFF
--- a/content/interpreters/rbx.haml
+++ b/content/interpreters/rbx.haml
@@ -31,16 +31,9 @@
 
 %p
   If you're installing rubinius on Ubuntu and you have issues with makeinfo
-  missing, you can solve it by first installing the texi2html package by:
+  missing, you can solve it by installing the texinfo package by:
 
 %pre.code
   :preserve
-     $ sudo apt-get install texi2html
-
-%p
-  And then symlinking it to the makeinfo executable by running:
-
-%pre.code
-  :preserve
-    $ sudo ln -s /usr/bin/texi2html /usr/bin/makeinfo
+     $ sudo apt-get install texinfo
 


### PR DESCRIPTION
As texinfo package for Ubuntu contains makeinfo executable, I corrected the dependency installation solution - there's no need for additional symlinking.
