### PR TITLE
Fixing a typo on installation instructions

### DIFF
--- a/content/rvm/install.haml
+++ b/content/rvm/install.haml
@@ -87,7 +87,7 @@
 
 %h3 Installing / updating the latest rvm from the latest released source tarball
 
-= sh_cmd "curl -s https://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-installer --version lastest"
+= sh_cmd "curl -s https://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-installer --version latest"
 
 %h3 Installing a specific version
 


### PR DESCRIPTION
The installation instructions specify a "lastest" revision where they should specify "latest"

Thanks for the link in response to https://twitter.com/#!/jayunit/status/65156027183673344 Wayne - I missed the rvm-site repo when I looked before.
