### PR TITLE
Install as root now configures rvm function globally.

### DIFF
--- a/content/rvm/install.haml
+++ b/content/rvm/install.haml
@@ -64,12 +64,8 @@
 
 %h4 Multi-User:
 
-%pre.code
-  :preserve
-    user$ echo '[[ -s "/usr/local/rvm/scripts/rvm" ]] && . "/usr/local/rvm/scripts/rvm" # Load RVM function' >> ~/.bash_profile
-
 %p
-  %em Multi-User Install Note: The rvm function must be configured for every user you wish to use rvm.
+  The rvm function will be automatically configured for every user on the system if you install as root.
 
 
 %h3 3. Reload shell configuration &amp; test


### PR DESCRIPTION
Updated to reflect that rvm function is globally sourced by default if you are crazy enough to install as root (no manual step necessary).

Thanks,

Andrew.
