### PR TITLE
fixed typo: 'directory' instead of 'directly'

### DIFF
--- a/content/workflow/projects.haml
+++ b/content/workflow/projects.haml
@@ -23,7 +23,7 @@
 = sh_cmd "echo 'rvm ree@tedxperth --create' > .rvmrc"
 
 %p
-  Inside the root of your project. This tells rvm that everytime we change in to the directly,
+  Inside the root of your project. This tells rvm that everytime we change in to the directory,
   it should use ree with the tedxperth gemset, creating the gemset if it doesn't exist.
 
 %p


### PR DESCRIPTION
"This tells rvm that everytime we change in to the directly," doesn’t quite have a ring to it…
