### PR TITLE
Delete comment about lack of 1.9.3.

### DIFF
--- a/content/rubies/installing.haml
+++ b/content/rubies/installing.haml
@@ -154,8 +154,6 @@
   :preserve
     $ rvm install ruby-1.9.2-head
     $ rvm use ruby-1.9.2-head
-%p
-  Note that as of this writing 1.9.3 has no repository branch and thus "1.9.3-head" IS "ruby-head".
 
 %h1 Install on Use
 %p


### PR DESCRIPTION
1.9.3-head now exists, so this statement has become obsolete, as predicted by the author.
