### PR TITLE
add 'src/' path and closing quote

### DIFF
--- a/content/support/troubleshooting.haml
+++ b/content/support/troubleshooting.haml
@@ -32,7 +32,7 @@
   If you have trouble installing ruby-debug19 try installing with the following command:
 %pre.code
   :preserve
-    $ gem install ruby-debug19 -- --with-ruby-include="${rvm_path}/${rvm_env_string//@*}
+    $ gem install ruby-debug19 -- --with-ruby-include="${rvm_path}/src/${rvm_env_string//@*}"
 
 %a{:href => "#", :name => "segfault"}
 %h2


### PR DESCRIPTION
fixes the invocation for installing ruby-debug190 on the troubleshoooting page
