### PR TITLE
Improve consistency between package pages

### DIFF
--- a/content/packages/openssl.haml
+++ b/content/packages/openssl.haml
@@ -45,7 +45,7 @@
     :preserve
       $ rvm pkg install openssl
       $ rvm remove 1.9.2
-      $ rvm install 1.9.2 --with-openssl-dir=$HOME/.rvm/usr
+      $ rvm install 1.9.2 --with-openssl-dir=$rvm_path/usr
 
 %p
   Adjust the location if you have a root install to '/usr/local/rvm/usr'


### PR DESCRIPTION
Changed the OpenSSL page to use '$rvm_path/usr' rather than '$HOME/.rvm/usr' .
