### PR TITLE
Fix install of rbx on OS X Lion with MacPorts

### DIFF
--- a/content/integration/macports.haml
+++ b/content/integration/macports.haml
@@ -17,8 +17,8 @@
 %pre.code
   :preserve
     export CFLAGS="-O2 -arch x86_64"
-    export LDFLAGS="-L/opt/local/lib"
-    export CPPFLAGS="-I/opt/local/include"
+    export LDFLAGS="-L$HOME/.rvm/usr/lib -L/opt/local/lib"
+    export CPPFLAGS="-I$HOME/.rvm/usr/include -I/opt/local/include"
 
 %p
   First install MacPorts and a base MacPort ruby like 1.8.7,


### PR DESCRIPTION
mod: Prefix compile flags with rvm's paths to allow installation of
rbx to pick up rvm's package installs of openssl, readline, etc.
