### PR TITLE
Constrain special compile flag declarations to rvm

### DIFF
--- a/content/integration/macports.haml
+++ b/content/integration/macports.haml
@@ -5,14 +5,14 @@
 
 %p
   In order to use MacPorts GCC,
-  set the following variables in your .bashrc / .bash_profile / shell:
+  set the following variables in your $HOME/.rvmrc:
 %pre.code
   :preserve
     export CC="/usr/bin/gcc-4.2"
 
 %p
   In order to use MacPorts libraries when installing RVM Rubies,
-  set the following variables in your .bashrc / .bash_profile / shell:
+  set the following variables in your $HOME/.rvmrc:
 
 %pre.code
   :preserve


### PR DESCRIPTION
Compile flags for `rvm install` should not go in something like
~/.bashrc. That could cause other installs to use rvm-specific packages.
They belong in ~/.rvmrc instead where they're constrained to use by rvm.
Compile flag declarations in something like ~/.bashrc will be ignored
for anyone who defines those flags in ~/.rvmrc, as rvm will clobber the
~/.bashrc (et al.) flag declarations.
