### PR TITLE
Fix docs on Passenger integration

### DIFF
--- a/content/integration/passenger.haml
+++ b/content/integration/passenger.haml
@@ -56,14 +56,14 @@
       end
     end
 
-    # Select the correct item for which you use below.
-    # If you're not using bundler, remove it completely.
-    #
-    # # If we're using a Bundler 1.0 beta
-    # ENV['BUNDLE_GEMFILE'] = File.expand_path('../Gemfile', File.dirname(__FILE__))
-    # require 'bundler/setup'
-    #
-    # # Or Bundler 0.9...
+    # Pick the lines for your version of Bundler
+    # If you're not using Bundler at all, remove all of them
+
+    # Require Bundler 1.0 
+    ENV['BUNDLE_GEMFILE'] = File.expand_path('../Gemfile', File.dirname(__FILE__))
+    require 'bundler/setup'
+
+    # Require Bundler 0/9
     # if File.exist?(".bundle/environment.rb")
     #   require '.bundle/environment'
     # else


### PR DESCRIPTION
Hi,

I've been solving this problem for, like, the fifth time, so I decided to fix the docs.

They weren't clear on what you _must_ require Bundler in setup_load_paths.rb, otherwise it won't work, and they weren't mentioning Bundler 1.0 non-beta (so I thought that Bundler 1.0 doesn't need any additional code).

1) I made the Bundler 1.0 lines uncommented by default as most people are using Bundler now.
2) I changed 'Bundler 1.0 beta' to 'Bundler 1.0'
