### PR TITLE
added page for init.d for better ability to find how to use rvm with ruby scripts that get started with it

### DIFF
--- a/content/integration/init-d.haml
+++ b/content/integration/init-d.haml
@@ -1,0 +1,50 @@
+= breadcrumbs "Integration", "init.d Services"
+
+%a{:name => "sketchup"}
+%h1 Using RVM and Ruby-based services that start via init.d
+
+%p
+  To use any Ruby application that needs to be started with init.d (e.g., god, unicorn, thin) with
+  RVM, you need to generate a wrapper script. Namely, you need to set it up
+  so that there is an alternative executable that loads the correct gemset.
+
+%p
+  As an example, if you'd installed god under Ruby Enterprise Edition in the
+  management gemset (aka. "ree@management"), you would do the following:
+
+%pre.code
+  :preserve
+    rvm wrapper ree@management bootup god
+
+%p
+  Running this command will generate the executable bootup_god in ~/.rvm/bin or,
+  if you have installed RVM system wide, in /usr/local/rvm/bin.
+
+%p
+  Thus, when setting up your init files, instead of using the direct path to god, you would
+  instead use the path to bootup_god. As an example, you could add the following
+  to /etc/rc.local (although we suggest using the init.d system of choice for your
+  operating system):
+
+%pre.code
+  :preserve
+    /home/your-long/.rvm/bin/bootup_god -c /path/to/config.god --log /var/log/god.log --no-syslog --log-level warn
+
+%p
+  Also, please note that any gems you reference in your god configurations that are
+  under other gemsets or rubies (such as thin or thor), you will need to also generate
+  wrapper scripts (and hence, use the path for them) via:
+
+%pre.code
+  :preserve
+    rvm wrapper ruby@gemset [scope] [binary-name]
+
+%p
+  Where [scope] is the prefix for the executable (e.g. god before)
+  and binary-name is the binary to generate a wrapper for. Hence, creating
+  %tt $rvm_bin_path/[scope]_[binary-name]
+  \- e.g. ~/.rvm/bin/myapp_thin
+
+%p
+  Lastly, you would replace all calls to 'thin' or the path to 'thin' in your god
+  configs with the path to the wrapper instead.

--- a/content/integration/init-d.yaml
+++ b/content/integration/init-d.yaml
@@ -1,0 +1,2 @@
+---
+title: "RVM and Ruby-based services started with init.d"

--- a/layouts/shared/doc.haml
+++ b/layouts/shared/doc.haml
@@ -173,6 +173,8 @@
       %li
         %a{:href => "/integration/god/"} God
       %li
+        %a{:href => "/integration/init-d/"} init.d Services
+      %li
         %a{:href => "/integration/hudson/"} Hudson
       %li
         %a{:href => "/integration/macports/"} MacPorts


### PR DESCRIPTION
It took me a while to find this information, because the page is about "integration with god," but I really only cared about how to use Ruby apps with rvm that get started with init.d. 

Recommendations I'll implement if they're agreeable to you: 
1) Remove "god" page and use the general init.d page (actually, set up a meta refresh with time of 0 so Google retains the page rank for the god page)

2) Or, is there a way to set up an actual 301 redirect on the server?

3) I might add something about "monit" to the page since people may be googling for things like "how to start unicorn with monit and rvm" 

Let me know if you're interested in any of those other things, and I'll go ahead and commit them too. I just left it as an addition to the site instead of removal since I wasn't sure how you'd handle the redirect.
