### PR TITLE
Switching RVM plugin to Tim Pope's.

### DIFF
--- a/content/integration/vim.haml
+++ b/content/integration/vim.haml
@@ -5,7 +5,7 @@
 
 %p
   If you wish to add rvm information to your vim status line, check out
-  %a{:href => "http://www.vim.org/scripts/script.php?script_id=3134"} rvm.vim.
+  %a{:href => "https://github.com/tpope/vim-rvm"} rvm.vim.
 
 
 %h2 MacVim with rvm rubies.


### PR DESCRIPTION
rvm.vim is no longer updated, we should use @tpope's vim-rvm.
