### PR TITLE
Install instructions, .bash_profile

### DIFF
--- a/content/rvm/install.haml
+++ b/content/rvm/install.haml
@@ -135,11 +135,11 @@
 
 %h3 3. Reload shell configuration &amp; test
 
-%p Close out your current shell or terminal session and open a new one. You may attempt reloading your .bash_profile with the following command:
+%p Close out your current shell or terminal session and open a new one. You may attempt reloading your ~/.bash_profile with the following command:
 
 %pre.code
   :preserve
-    user$ source .bash_profile
+    user$ source ~/.bash_profile
 
 %p
   However, closing out your current shell or terminal and opening a new one is the preferred way for initial installations.


### PR DESCRIPTION
Explicitly source the .bash_profile from within the user's home direcy instead of their current working directory
