### PR TITLE
Added missing link to RVM configuration

### DIFF
--- a/layouts/shared/doc.haml
+++ b/layouts/shared/doc.haml
@@ -14,6 +14,8 @@
       %li
         %a{:href => "/rvm/install/"} Installation
       %li
+        %a{:href => "/rvm/configuration/"} Configuration
+      %li
         %a{:href => "/rvm/upgrading/"} Upgrading
       %li
         %a{:href => "/rvm/cli/"} CLI


### PR DESCRIPTION
The link to the "RVM configuration" page is missing in the documentation index. This patch adds this link.
