### PR TITLE
Fixes #983 [https://github.com/wayneeseguin/rvm/issues/983].

### DIFF
--- a/content/packages/openssl.haml
+++ b/content/packages/openssl.haml
@@ -27,7 +27,7 @@
 
 %ul
   %li
-    require "openssl" # => false ?!
+    require "openssl" # !> LoadError: cannot load such file -- openssl
   %li
     Error compiling openssl due to openssl version 1.0.0* installed on the system.
 


### PR DESCRIPTION
Require raises a LoadError when a file can't be loaded. Its return value is irrelevant.
