### PR TITLE
Installing named rubies with '-' in the name ('rg-152') is not possible ...

### DIFF
--- a/content/rubies/rubygems.haml
+++ b/content/rubies/rubygems.haml
@@ -116,7 +116,7 @@
 
 %pre.code
   :preserve
-    $ rvm install ree -n rg-152
+    $ rvm install ree -n rg152
     $ rvm use ree-rg152
     $ gem --version
     1.8.10
@@ -139,4 +139,4 @@
     rvm rubies
 
     => ree-1.8.7-2011.03 [ i386 ]
-       ree-1.8.7-2011.03-rg-152 [ i386 ]
+       ree-1.8.7-2011.03-rg152 [ i386 ]


### PR DESCRIPTION
...and results in an error message. Using either an underscore ('rg_152') or no delimiter at all ('rg152') is fine.
