### PR TITLE
rvm does not need to be installed locally

### DIFF
--- a/content/integration/capistrano.haml
+++ b/content/integration/capistrano.haml
@@ -33,7 +33,7 @@ So integration can achieve the following:
 %ul(style="list-style: decimal")
   %li
     %a(href="#gem") gem:
-    If your rvm version on the server and locally are recent enough
+    If your rvm version on the server is recent enough
     (>= 1.11.3), you can use the
     %code.code rvm-capistrano
     gem.


### PR DESCRIPTION
I confirmed this by deploying via capistrano from a cygwin environment
that did not have rvm installed.
