### PR TITLE
Added autocreation rvmrc flag to gemset/creation page

### DIFF
--- a/content/gemsets/creating.haml
+++ b/content/gemsets/creating.haml
@@ -36,3 +36,9 @@
   like so:
 
 = sh_cmd "rvm use 1.9.2-head@albinochipmunk --create"
+
+%p
+  If you would like to create gemsets automatically when used, export this flag in your ~/.rvmrc or /etc/rvmrc file:
+%pre.code
+  :preserve
+    rvm_gemset_create_on_use_flag=1


### PR DESCRIPTION
I think this flag should be explained on the creation page as well, makes it easier to find it as there is a logical connection between creation and autocreation (currently it is on the usage page making it hard to find).
