### PR TITLE
Fixed the alias problem with curl

### DIFF
--- a/content/deployment/best-practices.haml
+++ b/content/deployment/best-practices.haml
@@ -46,9 +46,9 @@
   Now install RVM,
 %pre.code
   :preserve
-    appuser$ "curl" -L get.rvm.io | bash -s stable
+    appuser$ \curl -L get.rvm.io | bash -s stable
 %p
-  Please note that curl is quotes in double quotes, this prevents misbehaving if
+  Please note that there is a backslash before <b>curl</b>, this prevents misbehaving if
   you have aliased it with other options or use a .curlrc file for this. Once 
   you have RVM installed for the target application user, you are ready to setup
   the deployment!

--- a/content/integration/fish.haml
+++ b/content/integration/fish.haml
@@ -26,10 +26,10 @@ changes to environment variables, the second a wrapper around RVM for fish.
 %pre.code
   :preserve
      set -l GITHUB https://raw.github.com/lunks/fish-nuggets/master/functions
-     "curl" --create-dirs -o ~/.config/fish/functions/rvm.fish $GITHUB/rvm.fish
-     "curl" -o ~/.config/fish/functions/cd.fish $GITHUB/cd.fish
+     \curl --create-dirs -o ~/.config/fish/functions/rvm.fish $GITHUB/rvm.fish
+     \curl -o ~/.config/fish/functions/cd.fish $GITHUB/cd.fish
 %p
-  Note the double quotes around curl.
+  Note the backslash before <b>curl</b>.
 
 %h2 Usage
 %p

--- a/content/integration/zsh.haml
+++ b/content/integration/zsh.haml
@@ -36,7 +36,7 @@
 
 %pre.code
   :preserve
-    version="4.3.10" ; mkdir -p ~/.src && cd ~/.src && "curl" -O -L --create-dirs -C - http://downloads.sourceforge.net/project/zsh/zsh-dev/$version/zsh-$version.tar.bz2?use_mirror=voxel && tar jxf zsh-$version.tar.bz2* && cd zsh-$version && ./configure --prefix=/ && make && sudo make install
+    version="4.3.10" ; mkdir -p ~/.src && cd ~/.src && \curl -O -L --create-dirs -C - http://downloads.sourceforge.net/project/zsh/zsh-dev/$version/zsh-$version.tar.bz2?use_mirror=voxel && tar jxf zsh-$version.tar.bz2* && cd zsh-$version && ./configure --prefix=/ && make && sudo make install
 
 %p
   If you're using zsh (possibly with oh-my-zsh) and your prompt displays the current directory as "~rvm_rvmrc_cwd",

--- a/content/rvm/install.haml
+++ b/content/rvm/install.haml
@@ -9,16 +9,16 @@
   </strong>
 
 Install RVM with ruby:
-= sh_cmd "\"curl\" -L https://get.rvm.io | bash -s stable --ruby"
+= sh_cmd "\\curl -L https://get.rvm.io | bash -s stable --ruby"
 Additionally with rails:
-= sh_cmd "\"curl\" -L https://get.rvm.io | bash -s stable --rails"
+= sh_cmd "\\curl -L https://get.rvm.io | bash -s stable --rails"
 Or with rubinius, rails and puma:
-= sh_cmd "\"curl\" -L https://get.rvm.io | bash -s stable --ruby=rbx --gems=rails,puma"
+= sh_cmd "\\curl -L https://get.rvm.io | bash -s stable --ruby=rbx --gems=rails,puma"
 Finally, to install without the "rubygems-bundler" or "rvm" gems:
-= sh_cmd "\"curl\" -L https://get.rvm.io | bash -s stable --without-gems=\"rvm rubygems-bundler\""
+= sh_cmd "\\curl -L https://get.rvm.io | bash -s stable --without-gems=\"rvm rubygems-bundler\""
 
 %p
-  Point to be noted are, there are double quotes around curl. This prevents misbehaving if 
+  Point to be noted is, there is a backslash before <b>curl</b>. This prevents misbehaving if 
   you have aliased it with configuration in your ~/.curlrc file.
 
 %p
@@ -89,7 +89,7 @@ Finally, to install without the "rubygems-bundler" or "rvm" gems:
   %a{ :href => "https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer"}
     https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer
   You could also use full path for the installer:
-  = sh_cmd "curl https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer | bash -s stable"
+  = sh_cmd "\curl https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer | bash -s stable"
 
 %h2 Installation
 
@@ -100,17 +100,17 @@ Finally, to install without the "rubygems-bundler" or "rvm" gems:
   Installing the stable release version:
   %pre.code
     :preserve
-      user$ "curl" -L https://get.rvm.io | bash -s stable
+      user$ \curl -L https://get.rvm.io | bash -s stable
 %p
   To get the latest development state:
   %pre.code
     :preserve
-      user$ "curl" -L https://get.rvm.io | bash
+      user$ \curl -L https://get.rvm.io | bash
 %p
   For a Multi-User install you would execute the following:
   %pre.code
     :preserve
-      user$ "curl" -L https://get.rvm.io | sudo bash -s stable
+      user$ \curl -L https://get.rvm.io | sudo bash -s stable
   %strong
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Note: The Multi-User install instructions <i>must</i> be prefixed with the
     %a{:href => "/support/troubleshooting/#sudo"}
@@ -126,8 +126,8 @@ Finally, to install without the "rubygems-bundler" or "rvm" gems:
   Installing a specific version:
   %pre.code
     :preserve
-      user$ "curl" -L https://get.rvm.io | bash -s -- --version latest
-      user$ "curl" -L https://get.rvm.io | bash -s -- --branch [owner/][repo]
+      user$ \curl -L https://get.rvm.io | bash -s -- --version latest
+      user$ \curl -L https://get.rvm.io | bash -s -- --branch [owner/][repo]
   Prefix the 'bash' portion with 'sudo', of course, if you wish to apply this to a Multi_user
   Install. Please feel free to check out our
   %a{:href => "/rvm/upgrading/"}
@@ -138,14 +138,14 @@ Finally, to install without the "rubygems-bundler" or "rvm" gems:
   Debugging installation process:
   %pre.code
     :preserve
-      user$ "curl" -L https://get.rvm.io | bash -s -- --trace
+      user$ \curl -L https://get.rvm.io | bash -s -- --trace
 
 %p
   <strong>If the rvm install script does nothing or complains about certificates</strong>
   you can bypass this by adding a '-k' switch to the curl command:
   %pre.code
     :preserve
-      user$ "curl" -kL https://get.rvm.io | bash -s stable
+      user$ \curl -kL https://get.rvm.io | bash -s stable
 
 %h4 Single-User Install Location: ~/.rvm/
 %p
@@ -381,10 +381,10 @@ Finally, to install without the "rubygems-bundler" or "rvm" gems:
     #!/usr/bin/env bash
 
     # Install git
-    "curl" -L https://get-git.rvm.io | bash
+    \curl -L https://get-git.rvm.io | bash
 
     # Install RVM
-    "curl" -L https://get.rvm.io | bash -s stable
+    \curl -L https://get.rvm.io | bash -s stable
 
     # Install some Rubies
     source "$HOME/.rvm/scripts/rvm"
@@ -398,10 +398,10 @@ Finally, to install without the "rubygems-bundler" or "rvm" gems:
     #!/usr/bin/env bash
 
     # Install git
-    "curl" -L https://get-git.rvm.io | sudo bash
+    \curl -L https://get-git.rvm.io | sudo bash
 
     # Install RVM
-    "curl" -L https://get.rvm.io | sudo bash -s stable
+    \curl -L https://get.rvm.io | sudo bash -s stable
 
     # Install some Rubies
     source "/usr/local/rvm/scripts/rvm"

--- a/content/rvm/upgrading.haml
+++ b/content/rvm/upgrading.haml
@@ -45,11 +45,11 @@
   Installer also will update RVM:
 %pre.code
   :preserve
-    $ "curl" -L https://get.rvm.io | bash -s stable # update to stable
-    $ "curl" -L https://get.rvm.io | bash -s head   # update to head
+    $ \curl -L https://get.rvm.io | bash -s stable # update to stable
+    $ \curl -L https://get.rvm.io | bash -s head   # update to head
     $ rvm reload
 %p
-  Yes, there's double quote around the curl. It is important to reload after using installer for update.
+  Yes, there's a backslash before the <b>curl</b>. It is important to reload after using installer for update.
 
 %h3
   Auto update sourcing line


### PR DESCRIPTION
There are no guarantee if user has aliased his/her curl for their own purposes. For example, a use might have `--remote-name` in their ~/.curlrc file (or an alias to this in their ~/.bash_aliases or similar file) for ease of their use.

Adding double quotes around **curl** makes clear that it will not conflict if curl has been already  aliased, and will run without the alias or the configs in ~/.curlrc file.

If you have doubt, add these lines in your `~/.curlrc` file and proceed with installation of rvm from scratch:

> --remote-name
> -C -
> --location

Still not ready to believe? See a irc log of #rvm [here](http://pastebin.com/0CjqkSKt) _(modified a little bit)_
