### PR TITLE
Fix for issue #133 : XTerm integration command is incorrect

### DIFF
--- a/content/integration/xterm.haml
+++ b/content/integration/xterm.haml
@@ -10,7 +10,7 @@
   Multi-user RVM creates a script in /etc/profile.d, which is being sourced on startup. By default, xterm runs bash as usual, non-login shell, therefore skipping /etc/profile* and executing only ~/.bashrc
 
 %p
-  For RVM to work properly, you have to set 'xterm*loginShell: true' in your $HOME/.Xdefaults file and execute 'xrdb .Xdefaults', or execute 'xterm -ls' which makes xterm launch as a login shell.
+  For RVM to work properly, you have to set 'xterm*loginShell: true' in your $HOME/.Xdefaults file and execute 'xrdb $HOME/.Xdefaults', or execute 'xterm -ls' which makes xterm launch as a login shell.
 
 %p
   Read the explanation of what


### PR DESCRIPTION
This pull request fix the issue #133 : XTerm integration command is incorrect

https://github.com/rvm/rvm-site/issues/133
