### PR TITLE
minor typo on Project Workflow page

### DIFF
--- a/content/workflow/projects.haml
+++ b/content/workflow/projects.haml
@@ -75,7 +75,7 @@
 
 %p
   To look at the other extreme, it is possible to use a combined set of features to automate
-  many levels of setup and to make live easier when working with projects in general.
+  many levels of setup and to make life easier when working with projects in general.
 
 %p
   This approach, as seen in


### PR DESCRIPTION
On the _Typical RVM Project Workflow_ page, "live" should be "life" in the phrase:
make live easier

Thanks for RVM.
