### PR TITLE
New flag to prevent loading `bundle exec`

### DIFF
--- a/content/integration/bundler.haml
+++ b/content/integration/bundler.haml
@@ -38,7 +38,7 @@
 
       To prevent loading `bundle exec`:
 
-          NOEXEC=0 rake ...
+          NOEXEC_DISABLE=1 rake ...
 
       For more information read:
 


### PR DESCRIPTION
Use `NOEXEC_DISABLE=1` instead of `NOEXEC=0` to skip Bundler.setup, as documented here:
https://github.com/mpapis/rubygems-bundler

If you use NOEXEC=0 as, you get this deprecation warning:
`Warning, 'NOEXEC' environment variable is deprecated,
switch to 'NOEXEC_DISABLE=1'`
