### PR TITLE
Show install of another Ruby but preserve lazy cut-and-paste.

### DIFF
--- a/content/index.haml
+++ b/content/index.haml
@@ -13,8 +13,8 @@
 
 %ul.square
   %li
-    install RVM(follow next link!):
-    = sh_cmd "\\curl -L https://get.rvm.io | bash -s stable --ruby"
+    Install RVM with a Ruby (latest will be Ruby 2, but you may specify):
+    = sh_cmd "\\curl -L https://get.rvm.io | bash -s stable --ruby # Or, --ruby=1.9.3"
   %li
     and visit the
     %a{:href => "/rvm/install/"}


### PR DESCRIPTION
I think this is helpful because users still want to install 1.9.3 (or at least, some non-Ruby 2 version).
