### PR TITLE
FAQ Addition: Disable automatic switching of ruby-version

### DIFF
--- a/content/support/faq.haml
+++ b/content/support/faq.haml
@@ -182,10 +182,10 @@ title: RVM Frequently Asked Questions
     rvm_archflags="-arch x86_64"
 
 %h2
-  I'm using ruby tag for selecting the ruby version in production (heroku), how do I use another ruby version for development?
+  I'm using the 'ruby' tag to select the ruby version in production (heroku) - how do I use another ruby version for development?
 %p
   Place a .ruby-version file in the project directory with the version of ruby to use for development purposes.
-  This file will be found by RVM before the Gemfile, and since .ruby-version is RVM-only, it wont affect heroku.
+  This file will loaded by RVM before the Gemfile, and since .ruby-version is ignored by heroku, it wont affect the application in production.
 %p
   The .ruby-version file can contain a specific ruby version, or
   be left empty in order to just use the currently selected ruby version.


### PR DESCRIPTION
How to disable automatic switching on rubies, when the ruby version for production is specified in the Gemfile.

I am not sure this is the correct place to put it, but since I could not find a description of the different types project files and their load order, I found this to be the best place.
