### PR TITLE
Update install.haml

### DIFF
--- a/content/rvm/install.haml
+++ b/content/rvm/install.haml
@@ -43,7 +43,7 @@ For a progress bar when downloading RVM / Rubies:
 %p
   If you're an existing RVM user and you don't want RVM to attempt to setup
   your shell to load RVM, you can opt out of this at install time by exporting
-  rvm_ignore_dotfiles=yes, or opt out permanatly by setting this in your rvmrc.
+  rvm_ignore_dotfiles=yes, or opt out permanently by setting this in your rvmrc.
 
 %p
   You can also:


### PR DESCRIPTION
Typo on the word permanently in the content/rvm/install.haml
