### PR TITLE
Moved the '$' in shell command code helper to css.

### DIFF
--- a/content/assets/css/screen.sass
+++ b/content/assets/css/screen.sass
@@ -324,6 +324,8 @@ $title-background: #292929
     background: #fff
     border: 1px solid maroon
     overflow: auto
+  pre.code-shell-cmd:before
+    content: '$ '
   ul.disk
     list-style: disc
   ul, ul.circle

--- a/lib/code_helper.rb
+++ b/lib/code_helper.rb
@@ -3,7 +3,7 @@
 module CodeHelper
 
   def sh_cmd(command)
-    "<pre class='code'>$ #{html_escape command}</pre>"
+    "<pre class='code code-shell-cmd' title='triple click to select command'>#{html_escape command}</pre>"
   end
 
   def li_code(code, text)


### PR DESCRIPTION
Triple clicking on shell command currently selects the '$' which is only there to denote command prompt. In this change, shell commands remain prefixed with the same '$' but it is done using a :before pseudo-class in css.

This change will enable users to triple click and copy the just the command.
