### PR TITLE
CSS fix for ignored space after command prompt

### DIFF
--- a/content/assets/css/screen.sass
+++ b/content/assets/css/screen.sass
@@ -325,7 +325,7 @@ $title-background: #292929
     border: 1px solid maroon
     overflow: auto
   pre.code-shell-cmd:before
-    content: '$ '
+    content: '$\00A0'
   ul.disk
     list-style: disc
   ul, ul.circle


### PR DESCRIPTION
Firefox ignores the whitespace in 'content' attribute of pseudo elements. Replaced the whitespace with '\00a0'

ref: https://developer.mozilla.org/en-US/docs/Web/CSS/content

thanks to @envygeeks for pointing it out in https://github.com/rvm/rvm-site/pull/182
