### PR TITLE
integration/fish: updated installation instructions

### DIFF
--- a/content/integration/fish.md
+++ b/content/integration/fish.md
@@ -17,13 +17,9 @@ Install
 Setup
 -----
 
-Download the fish functions from GitHub, the first a utility function to capture the changes to environment variables, the second a wrapper around RVM for fish.
+Download the fish functions from GitHub.
 
-    set -l GITHUB https://raw.github.com/lunks/fish-nuggets/master/functions
-    \curl --create-dirs -o ~/.config/fish/functions/rvm.fish $GITHUB/rvm.fish
-    \curl -o ~/.config/fish/functions/cd.fish $GITHUB/cd.fish
-
-Note the backslash before **curl**.
+    curl --create-dirs -o ~/.config/fish/functions/rvm.fish https://raw.github.com/lunks/fish-nuggets/master/functions/rvm.fish
 
 Usage
 -----


### PR DESCRIPTION
lunks/fish-nuggets@7d95eada74fe4e363c779a60f611a378dbe088fa breaks snippet, so I'm fixing it back
