### PR TITLE
Remove extra trailing quote typo in example.

### DIFF
--- a/content/development/contributing.haml
+++ b/content/development/contributing.haml
@@ -74,7 +74,7 @@ title: Contributing to the RVM project.
     %pre.code
       :preserve
         $ ./install --path $HOME/.rvm-dev
-        $ rvm switch $HOME/.rvm-dev"
+        $ rvm switch $HOME/.rvm-dev
 
   %li
     It helps to use bash as your primary shell, but for some features you'll


### PR DESCRIPTION
Removed the trailing quote to make the command `rvm switch $HOME/.rvm-dev` copy-pastable. (Could of course instead add an additional starting quote but just removed to match example above it.)
