### PR TITLE
Update zsh + iTerm2 instructions

### DIFF
--- a/content/integration/zsh.haml
+++ b/content/integration/zsh.haml
@@ -73,12 +73,18 @@ title: "ZSH Integration with RVM."
   zsh + iTerm2
 
 %p
-  If you are using iTerm2's feature allowing you to open new tabs / windows and
+  Make sure in iTerm2 Preferences: 
+  %strong 
+    Login shell
+  option is set (do not use Command option). This is required for RVM to work.
+  
+%p
+  If you are still getting
   %strong
-    "Reuse Previous Tab's Directory"
-  then you will want to add the following line to the bottom of your .zshrc
+    rvm is not a function
+  errors on iTerm, try:
 %pre.code
-  __rvm_project_rvmrc
+  rvm get stable --auto-dotfiles
 
 %h2
   zsh + oh my zsh


### PR DESCRIPTION
- Remove `__rvm_project_rvmrc`
- Add Login shell option required
- Add `rvm get stable --auto-dotfiles` if getting rvm is not a function errors
