### PR TITLE
Receive public key with the entire fingerprint for greater security

### DIFF
--- a/content/index.haml
+++ b/content/index.haml
@@ -18,7 +18,7 @@ title: RVM Ruby Version Manager - Documentation
 %ul.square
   %li
     Install RVM:
-    = sh_cmd "gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3"
+    = sh_cmd "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
     = sh_cmd "\\curl -sSL https://get.rvm.io | bash -s stable"
     For all in one installation append
     %code --rails

--- a/content/rvm/install.md
+++ b/content/rvm/install.md
@@ -8,7 +8,7 @@ title: Installing RVM
 
 Before any other step install [mpapis](/authors/mpapis/) [public key](https://keybase.io/mpapis) (might need `gpg2`) (see [security](/rvm/security/))
 
-    gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
+    gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 
 **Unless doing guided install you should read all sub-sections under the [RVM Section](/rvm/).**
 

--- a/content/rvm/security.md
+++ b/content/rvm/security.md
@@ -7,14 +7,14 @@ user. But there is the first step that would need to be done manually -
 verifying the `rvm-installer` was signed by the given key:
 
     # Install mpapis public key (might need `gpg2` and or `sudo`)
-    gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
+    gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 
     # Download the installer
     \curl -O https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer
     \curl -O https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer.asc
 
-    # Verify the installer signature (might need `gpg2`)
-    gpg --verify rvm-installer.asc
+    # Verify the installer signature (might need `gpg2`), and if it validates...
+    gpg --verify rvm-installer.asc &&
 
     # Run the installer
     bash rvm-installer stable


### PR DESCRIPTION
The GPG short id is no longer considered sufficient to ensure the authenticity of a key.  This is troubling, since so much software delivery relies on short ids to provide keys!  See http://un.parsed.net/index.php/2013/231 for more info.  The `gpg --recv-key` has little benefit if an attacker is able to simply generate a key with the same short key id.  Amending command to receive key with full fingerprint.

Also, in security.md changing the verify command to add a `&&` at the end, so that the install is only run if the signature actually validates.