### PR TITLE
Fix link to MagLev homepage

### DIFF
--- a/content/interpreters/maglev.haml
+++ b/content/interpreters/maglev.haml
@@ -30,7 +30,7 @@ title: "MagLev"
   Community Resources
 %ul
   %li
-    %a{:href => "http://maglev.gemstone.com/", :target => "_blank"}
+    %a{:href => "http://maglev.github.io/", :target => "_blank"}
       http://maglev.gemstone.com/
   %li
     %a{:href => "https://github.com/MagLev/maglev/blob/master/docs/Maglev_c_extensions.md"}


### PR DESCRIPTION
`http://blog.ninjahideout.com/posts/the-path-to-better-rvm-and-passenger-integration` yields Application Error so I didn't remove it in case it's going to come back up