### PR TITLE
Fixed order of arguments

### DIFF
--- a/content/integration/bundler.md
+++ b/content/integration/bundler.md
@@ -66,7 +66,7 @@ From now on, any project which was generated this way will automatically add `$P
 
 Install all executables into single location
 
-    bundle config bin ~/.bundler_binstubs --global
+    bundle config --global bin ~/.bundler_binstubs
 
 And add it to `PATH`:
 


### PR DESCRIPTION
Global needs to be before the bin option, otherwise it becomes part of
the path.