### PR TITLE
Explicitly link to ubuntu install instructions

### DIFF
--- a/content/rvm/install.md
+++ b/content/rvm/install.md
@@ -20,7 +20,7 @@ As a first step install [mpapis](/authors/mpapis/) [public key](https://keybase.
 
 ### Ubuntu
 
-RVM have dedicated Ubuntu package, so please follow instructions posted here: https://github.com/rvm/ubuntu_rvm
+RVM have dedicated Ubuntu package, so please follow instructions posted here: [https://github.com/rvm/ubuntu_rvm](https://github.com/rvm/ubuntu_rvm)
  
 If you need a different (newer) version of RVM, after installing base version of RVM check the [Upgrading](/rvm/upgrading) section. 
 


### PR DESCRIPTION
It looks like some Markdown engines will automatically turn this into a link but on rvm.io, I have to copy/paste it to the URL bar.

