### PR TITLE
first pass at adding Algolia DocSearch

### DIFF
--- a/content/assets/css/algolia-docsearch.sass
+++ b/content/assets/css/algolia-docsearch.sass
@@ -1,0 +1,5 @@
+.algolia-autocomplete .algolia-docsearch-suggestion--category-header
+  color: maroon
+
+.algolia-autocomplete .algolia-docsearch-suggestion--title
+  color: #555658

--- a/layouts/shared/doc_menu.haml
+++ b/layouts/shared/doc_menu.haml
@@ -3,6 +3,11 @@
     = link_to 'RVM Documentation Index', '/', style: "color: red;"
     |
     = link_to 'RVM Blog', '/blog/'
+
+  .headline
+    <label for="docsearch-input">Search:</label>
+    <input id="docsearch-input" type="text" />
+
   .column
     = menu_for("/rvm/")
 

--- a/layouts/shared/footer.haml
+++ b/layouts/shared/footer.haml
@@ -40,3 +40,13 @@
     ga('send', 'pageview');
     ga('create', 'UA-45354940-1', 'rvm.io', {'name': 'ga_mpapis'}); // owner mpapis@gmail.com
     ga('ga_mpapis.send', 'pageview');
+
+  :preserve
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+  :javascript
+    docsearch({
+    apiKey: '511953e6f628103639db56a6f0f96977',
+    indexName: 'rvm',
+    inputSelector: '#docsearch-input',
+    debug: false // Set debug to true if you want to inspect the dropdown
+    });

--- a/layouts/shared/html-head.haml
+++ b/layouts/shared/html-head.haml
@@ -3,6 +3,8 @@
     RVM: Ruby Version Manager -
     = @item[:title]
   %link{ :href => "/css/screen.css", :rel => "stylesheet", :type => "text/css", :media => "screen" }
+  %link{ :href => "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css", :rel => "stylesheet", :type => "text/css" }
+  %link{ :href => "/css/algolia-docsearch.css", :rel => "stylesheet", :type => "text/css" }
   %meta{ :content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type" }
   %meta{ :name => "google-site-verification", :content => "w2V78a6cwiHD5Gm8yvlTP21xZ1YgVguDdC0JGDEA2d0" }
   = add_feed_link


### PR DESCRIPTION
Hello!

My name is Dan. I'm a developer advocate with Algolia ([web](https://www.algolia.com), [github](https://github.com/Algolia)). Recently, our very own @redox reached out to @mpapis regarding [DocSearch](https://community.algolia.com/docsearch/), which is a documentation search service that we provide for free to, well, just about anybody that wants it. We power the search on lots of other OSS and community projects already, including React, Bootstrap, and more. 

I know that you're all super busy, so to make things as easy as possible, I took some time to prepare this small PR. 😄 Basically this adds a little search bar in the documentation index section. Results are quickly returned as-you-type in a dropdown and link directly to the doc page in question:
<img width="529" alt="image" src="https://user-images.githubusercontent.com/625232/33177846-56850092-d064-11e7-8093-4817459002a0.png">

The results themselves are generated from your site. We scrape and parse the HTML (basically looking for `h1`'s and `p`'s) and build an index from that. The [scraper](https://github.com/algolia/docsearch-scraper) and configs are all OSS if you're interested in taking a look - your config is [right here](https://github.com/algolia/docsearch-configs/blob/master/configs/rvm.json).

The UX is pretty customisable. I set up a simple `.sass` file that uses some of the colours from your site. Please feel free to make it look however you want. In any case, we're actively indexing your site, so the search bar is totally usable _right now_.

On a personal note, I've used RVM off and on for years, and it's been really helpful. Thanks for all the work you've collectively poured into it! I hope you find this contribution helpful, too. 👍 