### PR TITLE
security.md: Remove trailing && characters

### DIFF
--- a/content/rvm/security.md
+++ b/content/rvm/security.md
@@ -14,9 +14,9 @@ verifying the `rvm-installer` was signed by the given key:
     \curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc
 
     # Verify the installer signature (might need `gpg2`), and if it validates...
-    gpg --verify rvm-installer.asc &&
+    gpg --verify rvm-installer.asc
 
-    # Run the installer
+    # ...run the installer
     bash rvm-installer stable
 
 In rare cases the `gpg --keyserver` is failing, use this instead:

--- a/content/rvm/security.md
+++ b/content/rvm/security.md
@@ -13,11 +13,9 @@ verifying the `rvm-installer` was signed by the given key:
     \curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer
     \curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc
 
-    # Verify the installer signature (might need `gpg2`), and if it validates...
-    gpg --verify rvm-installer.asc
-
-    # ...run the installer
-    bash rvm-installer stable
+    # Verify the installer signature (might need `gpg2`), and if it validates, run the installer.
+    gpg --verify rvm-installer.asc && \
+      bash rvm-installer stable
 
 In rare cases the `gpg --keyserver` is failing, use this instead:
 


### PR DESCRIPTION
While I can understand _some_ of the reason for them being there, it makes it harder to copy & paste the commands.

(If we want them to remain, we could at least add a trailing \ character so that you can add the `bash rvm-installer stable` to the following line.)