### PR TITLE
Remove sks keyservers

### DIFF
--- a/content/rvm/install.md
+++ b/content/rvm/install.md
@@ -10,7 +10,7 @@ RVM supports most UNIX like systems and Windows (with [Cygwin](https://cygwin.co
 
 As a first step install GPG keys used to verify installation package:
 
-    gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+    gpg --keyserver hkp://keys.openpgp.org --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 
 In case you encounter an issues check [security](/rvm/security)
 

--- a/content/rvm/security.md
+++ b/content/rvm/security.md
@@ -18,13 +18,13 @@ run our code - trust our keys. Here are the keys from our maintainers:
 
 As a first step, before attempting RVM install, you should install `gpg2` and import those keys:
 
-    gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+    gpg --keyserver hkp://keys.openpgp.org --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 
 If you encounter problem with the key server above, try a different one. Some alternatives are presented below:
 
-* hkp://ipv4.pool.sks-keyservers.net
 * hkp://pgp.mit.edu
 * hkp://keyserver.pgp.com
+* hkp://keyserver.ubuntu.com
 
 ### Firewall issues
 


### PR DESCRIPTION
The service is gone and isn't coming back. They officially deprecated the service, and removed the dns records.

https://unix.stackexchange.com/questions/656205/sks-keyservers-gone-what-to-use-instead

There are other alternatives, and keys.openpgp.org seems one of the most promising:

https://www.reddit.com/r/GnuPG/comments/ix2gdj/what_pgp_key_server_to_use/
https://superuser.com/questions/227991/where-to-upload-pgp-public-key-are-keyservers-still-surviving

Neither pgp.mit.edu nor keyserver.pgp.com work for me either. The openpgp keyserver is working well for me. keyserver.ubuntu.com seems to work as well.