### PR TITLE
Suggest installing latest RVM rather than stable

### DIFF
--- a/content/index.haml
+++ b/content/index.haml
@@ -23,11 +23,11 @@ title: RVM Ruby Version Manager - Documentation
     %a{:href => "/rvm/security"}
       security
   %li
-    Install RVM:
-    = sh_cmd "\\curl -sSL https://get.rvm.io | bash -s stable"
+    Install latest RVM:
+    = sh_cmd "\\curl -sSL https://get.rvm.io | bash"
   %li
     For installing RVM with default Ruby and Rails in one command, run:
-    = sh_cmd "\\curl -sSL https://get.rvm.io | bash -s stable --rails"
+    = sh_cmd "\\curl -sSL https://get.rvm.io | bash --rails"
   %li
     For more details and troubleshooting visit the
     %a{:href => "/rvm/install"}


### PR DESCRIPTION
Since stable releases are cut infrequently these days, it seems worth considering recommending installing latest rather than stable. Since RVM doesn't get frequent updates this seems relatively safe and maybe a better experience than getting an old, stable RVM.